### PR TITLE
Riverpod のドキュメントの URL を最新のものに変更

### DIFF
--- a/docs/sessions/state_management.md
+++ b/docs/sessions/state_management.md
@@ -71,7 +71,7 @@ flowchart TB
 
 [Riverpod]: https://pub.dev/packages/riverpod
 
-[Different Types of Providers]: https://docs-v2.riverpod.dev/docs/concepts/providers/#different-types-of-providers
+[Different Types of Providers]: https://riverpod.dev/docs/concepts/providers/#different-types-of-providers
 
 [Flutterの状態管理手法の選定]: https://medium.com/flutter-jp/state-1daa7fd66b94
 

--- a/docs/sessions/unit_test.md
+++ b/docs/sessions/unit_test.md
@@ -40,4 +40,4 @@ Flutter のテストは次の３つに分類されます。
 
 [Mockito]: https://docs.flutter.dev/cookbook/testing/unit/mocking
 
-[Riverpod Testing]: https://docs-v2.riverpod.dev/docs/cookbooks/testing
+[Riverpod Testing]: https://riverpod.dev/docs/essentials/testing

--- a/docs/sessions/widget_test.md
+++ b/docs/sessions/widget_test.md
@@ -29,4 +29,4 @@
 
 [Session9]: 10
 
-[Riverpod Testing]: https://docs-v2.riverpod.dev/docs/cookbooks/testing
+[Riverpod Testing]: https://riverpod.dev/docs/essentials/testing


### PR DESCRIPTION
## 提出前チェックリスト (必須)

- [x] [貢献ガイド] を読み、そこに記載されているプロセスに従って PR を送信しました。
- [x] この PR によって修正される Issue を少なくとも 1 つ挙げました。または簡単な修正。
- [x] 関連ドキュメントを更新・追加しました。

## Issue（オプション）

なし

`docs-v2.riverpod.dev` のドメインを `riverpod.dev` に変更して、代わりのページが存在していたらそのページに差し替えています。

<!-- Links -->

[貢献ガイド]: https://github.com/yumemi-inc/flutter-training-template/blob/main/docs/contributing/CONTRIBUTING.md
